### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: MATHIA CI/CD
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: [ "main", "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/bedah-kym/django-chat/security/code-scanning/2](https://github.com/bedah-kym/django-chat/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimal scopes required. This can be done at the workflow root (applies to all jobs) or per job. Since both jobs only need read access to repository contents, and the `build-and-deploy` job additionally needs to push to GitHub Container Registry (requiring `packages: write`), the cleanest fix is to define a default restrictive permissions block at the top level and, if needed, override or extend it for specific jobs.

The single best fix here, without changing any existing functionality, is to add a workflow‑level `permissions` block just below the `name:` (or just below `on:`) specifying `contents: read` and `packages: write`. This gives both jobs read access to the code and allows the `build-and-deploy` job to push images to GHCR via the `GITHUB_TOKEN` used in the docker login. No other permissions are required by the shown steps (they don’t create issues, modify PRs, etc.), so we keep the scope minimal. Concretely, edit `.github/workflows/main.yml` to insert:

```yml
permissions:
  contents: read
  packages: write
```

after line 2 (the blank line following `name: MATHIA CI/CD`). No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
