### PR TITLE
chore(orchestration): phase 1 — port v0.4 connector foundation from public/main

### DIFF
--- a/Backend/orchestration/action_catalog.py
+++ b/Backend/orchestration/action_catalog.py
@@ -454,6 +454,46 @@ for item in ACTION_CATALOG:
         _ALIAS_INDEX[str(alias).strip().lower()] = canonical
 
 
+def register_actions(entries: List[Dict[str, Any]]) -> None:
+    """
+    Dynamically register action catalog entries (from connector plugins).
+
+    Ported from public/main (kazi-core) as part of the v0.4 OSS foundation
+    port. This is what connector_registry calls when a new-style
+    BaseConnector subclass exposes get_action_catalog_entries() — its
+    entries get merged into ACTION_CATALOG so the rest of the runtime
+    (planner, executor, capability gates) sees them.
+
+    Existing actions with the same name are overwritten. Indexes are
+    kept in sync.
+    """
+    for raw_entry in entries:
+        entry = deepcopy(raw_entry)
+        action_name = entry.get("action")
+        if not action_name:
+            continue
+        existing_entry: Optional[Dict[str, Any]] = None
+        # Remove any existing entry with the same action name
+        for i, existing in enumerate(ACTION_CATALOG):
+            if existing["action"] == action_name:
+                existing_entry = existing
+                ACTION_CATALOG[i] = entry
+                break
+        else:
+            ACTION_CATALOG.append(entry)
+        if "router_required" not in entry:
+            if existing_entry is not None:
+                entry["router_required"] = existing_entry.get("router_required", True)
+            else:
+                # Dynamic/plugin-only actions should not be required in MCPRouter.
+                entry["router_required"] = False
+        # Update indexes
+        _ACTION_INDEX[action_name] = entry
+        _ALIAS_INDEX[action_name] = action_name
+        for alias in entry.get("aliases") or []:
+            _ALIAS_INDEX[str(alias).strip().lower()] = action_name
+
+
 def resolve_action_alias(action: Optional[str]) -> str:
     if not action:
         return ""

--- a/Backend/orchestration/base_connector.py
+++ b/Backend/orchestration/base_connector.py
@@ -1,21 +1,129 @@
 """
-Base connector class for MCP integrations
+Base connector class for Kazi plugins.
+
+All connectors (built-in and community) extend BaseConnector.
+This is the primary extension point for teaching Kazi new skills.
 """
-from typing import Dict, Any
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from orchestration.connectors.connector_error import ConnectorError
+
+logger = logging.getLogger(__name__)
 
 
 class BaseConnector:
-    """Base class for all external service connectors"""
+    """
+    Base class for all Kazi connectors.
 
-    async def execute(self, intent: Dict[str, Any], user: Any) -> Dict[str, Any]:
+    Subclass this to create a new connector. At minimum, implement:
+    - ``name``, ``actions`` class attributes
+    - ``get_action_catalog_entries()``
+    - ``execute()``
+
+    Example::
+
+        class WeatherConnector(BaseConnector):
+            name = "weather"
+            version = "1.0.0"
+            actions = ["get_weather"]
+            required_credentials = ["OPENWEATHER_API_KEY"]
+
+            def get_action_catalog_entries(self):
+                return [{
+                    "action": "get_weather",
+                    "service": "weather",
+                    "description": "Get current weather for a city",
+                    "params": {
+                        "city": {"type": "string", "required": True,
+                                 "description": "City name"},
+                    },
+                    "risk_level": "low",
+                }]
+
+            async def execute(self, parameters, context):
+                city = parameters.get("city")
+                # ... call weather API ...
+                return {"status": "success", "data": {...}}
+    """
+
+    # Override in subclass
+    name: str = ""
+    version: str = "0.1.0"
+    actions: List[str] = []
+    required_credentials: List[str] = []
+
+    def validate_config(self) -> Tuple[bool, str]:
         """
-        Execute the connector action based on intent
-
-        Args:
-            intent: Dictionary containing action and parameters
-            user: User object making the request
+        Check whether all required credentials are available.
 
         Returns:
-            Dictionary with execution results
+            (ok, message) — True if ready, False with explanation if not.
         """
-        raise NotImplementedError("Subclasses must implement execute() method")
+        missing = [
+            key for key in self.required_credentials
+            if not self.get_credential(key)
+        ]
+        if missing:
+            return False, f"{self.name}: missing credentials: {', '.join(missing)}"
+        return True, ""
+
+    def get_credential(self, key: str) -> Optional[str]:
+        """
+        Look up a credential by name.
+
+        Checks environment variables first, then Django settings.
+        Returns None if not found.
+        """
+        value = os.environ.get(key)
+        if value:
+            return value
+        try:
+            from django.conf import settings
+            return getattr(settings, key, None)
+        except Exception:
+            return None
+
+    def get_action_catalog_entries(self) -> List[Dict[str, Any]]:
+        """
+        Return ACTION_CATALOG-format entries for this connector's actions.
+
+        Each entry should be a dict with at least:
+        - action (str): unique action name
+        - service (str): service group name
+        - description (str): what this action does
+        - params (dict): parameter definitions
+        - risk_level (str): "low", "medium", or "high"
+
+        Optional fields:
+        - aliases (list[str]): alternative names
+        - confirmation_policy (str): "always", "high_risk", or "never"
+        - capability_gate (str): permission required
+        """
+        return []
+
+    async def execute(self, parameters: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Execute an action.
+
+        Args:
+            parameters: Dict with "action" key plus action-specific params.
+            context: Dict with "user_id", "room_id", and other context.
+
+        Returns:
+            Dict with at least a "status" key ("success" or "error").
+            On success, include "data" and/or "message".
+            On error, include "message" with a user-friendly explanation.
+
+        Raises:
+            ConnectorError: For structured errors with retry semantics.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement execute()"
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} name={self.name!r} v{self.version}>"

--- a/Backend/orchestration/connector_registry.py
+++ b/Backend/orchestration/connector_registry.py
@@ -1,0 +1,382 @@
+"""
+Connector auto-discovery and registration.
+
+Scans the connectors directory for BaseConnector subclasses and builds
+a unified action-to-connector map. Also loads legacy hardcoded connectors
+for backward compatibility, and scans the top-level `examples/connectors/`
+directory for example-style connectors when demo mode is enabled.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import importlib.util
+import inspect
+import logging
+import os
+import pkgutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Singleton caches
+_discovered_connectors: Optional[Dict[str, Any]] = None
+_registered_catalog_entries: List[Dict[str, Any]] = []
+
+
+def _env_flag_enabled(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_or_warn(connector_name: str, entry: Any) -> tuple:
+    """Validate a catalog entry; log a warning and return (False, errors)
+    on failure so the caller can skip the entry. See
+    docs/contracts/tool-schema.md.
+    """
+    from orchestration.contracts import validate_catalog_entry
+
+    ok, errors = validate_catalog_entry(entry)
+    if not ok:
+        action = entry.get("action") if isinstance(entry, dict) else "<unknown>"
+        logger.warning(
+            "Connector %s: catalog entry for action %r violates tool-schema "
+            "contract v1.0 and will be skipped: %s",
+            connector_name, action, "; ".join(errors),
+        )
+    return ok, errors
+
+
+def is_demo_mode() -> bool:
+    """KAZI_DEMO_MODE — boots the runtime with example connectors enabled,
+    no real credentials required, banner logged at startup. The single
+    flag readers should check; everything demo-related branches off it.
+    """
+    return _env_flag_enabled("KAZI_DEMO_MODE", default=False)
+
+
+def _examples_connectors_root() -> Optional[Path]:
+    """Locate `<repo_root>/examples/connectors/`.
+
+    The repo root sits two levels above this file:
+    `Backend/orchestration/connector_registry.py` -> repo root.
+    """
+    candidate = Path(__file__).resolve().parents[2] / "examples" / "connectors"
+    return candidate if candidate.is_dir() else None
+
+
+def discover_connectors() -> Dict[str, Any]:
+    """
+    Build the action-to-connector map by:
+    1. Loading legacy hardcoded connectors (backward compat)
+    2. Scanning connectors/ directory for new-style BaseConnector subclasses
+    3. Scanning installed packages for 'kazi.connectors' entry points
+
+    New-style connectors override legacy ones if there's a conflict.
+    """
+    global _discovered_connectors
+
+    if _discovered_connectors is not None:
+        return _discovered_connectors
+
+    connector_map: Dict[str, Any] = {}
+
+    # Step 1: Load legacy hardcoded connectors
+    legacy = _load_legacy_connectors()
+    connector_map.update(legacy)
+    logger.info("Loaded %d legacy connector mappings", len(legacy))
+
+    # Step 2: Scan connectors/ directory for new-style connectors
+    new_style = _scan_connectors_directory()
+    for connector in new_style:
+        ok, msg = connector.validate_config()
+        if not ok:
+            logger.warning("Connector %s skipped: %s", connector.name, msg)
+            continue
+
+        # Register actions
+        for action_name in connector.actions:
+            connector_map[action_name] = connector
+
+        # Collect catalog entries — validate against the v0.4 tool-schema
+        # contract (docs/contracts/tool-schema.md) before registering.
+        # Bad entries are skipped with a warning so a single typo doesn't
+        # break boot.
+        try:
+            entries = connector.get_action_catalog_entries()
+            for entry in entries:
+                ok, errors = _validate_or_warn(connector.name, entry)
+                if ok:
+                    _registered_catalog_entries.append(entry)
+        except Exception as exc:
+            logger.warning(
+                "Connector %s: get_action_catalog_entries() failed: %s",
+                connector.name, exc,
+            )
+
+        logger.info("Registered connector: %s v%s (%d actions)",
+                    connector.name, connector.version, len(connector.actions))
+
+    # Step 2b: When demo mode is on, also scan the top-level examples/
+    # directory so the canonical "copy this to start" connector boots
+    # with no opt-in required.
+    if is_demo_mode():
+        # Example connectors are routing-only: they go into the connector_map
+        # for direct invocation but NOT into the global action_catalog. That
+        # keeps the workflow executor's startup validator
+        # (validate_executor_action_mappings) happy — it would otherwise
+        # require an executor mapping for every example action.
+        # Demo workflows that need example actions invoke the connector
+        # directly through the registry, not through the workflow executor's
+        # action-catalog dispatch.
+        for connector in _scan_examples_directory():
+            ok, msg = connector.validate_config()
+            if not ok:
+                logger.warning("Example connector %s skipped: %s", connector.name, msg)
+                continue
+            for action_name in connector.actions:
+                connector_map[action_name] = connector
+            try:
+                entries = connector.get_action_catalog_entries()
+                for entry in entries:
+                    # Validate shape but do NOT add to _registered_catalog_entries.
+                    _validate_or_warn(connector.name, entry)
+            except Exception as exc:
+                logger.warning(
+                    "Example connector %s: get_action_catalog_entries() failed: %s",
+                    connector.name, exc,
+                )
+            logger.info(
+                "Registered example connector: %s v%s (%d actions, "
+                "routing-only — not in action catalog)",
+                connector.name, connector.version, len(connector.actions),
+            )
+
+    # Step 3: Scan entry points (for pip-installed community connectors)
+    entrypoint_connectors = _scan_entry_points()
+    for connector in entrypoint_connectors:
+        ok, msg = connector.validate_config()
+        if not ok:
+            logger.warning("Entry-point connector %s skipped: %s", connector.name, msg)
+            continue
+        for action_name in connector.actions:
+            connector_map[action_name] = connector
+        try:
+            entries = connector.get_action_catalog_entries()
+            _registered_catalog_entries.extend(entries)
+        except Exception as exc:
+            logger.warning(
+                "Entry-point connector %s: get_action_catalog_entries() failed: %s",
+                connector.name, exc,
+            )
+        logger.info("Registered entry-point connector: %s v%s",
+                    connector.name, connector.version)
+
+    # Step 4: Register all discovered catalog entries into the action catalog
+    if _registered_catalog_entries:
+        from orchestration.action_catalog import register_actions
+        register_actions(_registered_catalog_entries)
+        logger.info("Registered %d catalog entries from discovered connectors",
+                    len(_registered_catalog_entries))
+
+    _discovered_connectors = connector_map
+    logger.info("Total connector map: %d action mappings", len(connector_map))
+    return connector_map
+
+
+def get_registered_catalog_entries() -> List[Dict[str, Any]]:
+    """Return catalog entries from all discovered new-style connectors."""
+    return list(_registered_catalog_entries)
+
+
+def reset_registry() -> None:
+    """Clear the registry (useful for testing)."""
+    global _discovered_connectors, _registered_catalog_entries
+    _discovered_connectors = None
+    _registered_catalog_entries = []
+
+
+def _load_legacy_connectors() -> Dict[str, Any]:
+    """Load the existing hardcoded connector map for backward compatibility."""
+    try:
+        from orchestration.connectors.whatsapp_connector import WhatsAppConnector
+        from orchestration.connectors.intersend_connector import IntersendPayConnector
+        from orchestration.connectors.gmail_connector import GmailConnector
+        from orchestration.connectors.quota_connector import QuotaConnector
+        from orchestration.connectors.payment_connector import ReadOnlyPaymentConnector
+        from orchestration.connectors.invoice_connector import InvoiceConnector
+        from orchestration.connectors.travel_buses_connector import TravelBusesConnector
+        from orchestration.connectors.travel_hotels_connector import TravelHotelsConnector
+        from orchestration.connectors.travel_flights_connector import TravelFlightsConnector
+        from orchestration.connectors.travel_transfers_connector import TravelTransfersConnector
+        from orchestration.connectors.travel_events_connector import TravelEventsConnector
+        from orchestration.connectors.itinerary_connector import ItineraryConnector
+        from orchestration.mcp_router import (
+            CalendarConnector,
+            SearchConnector,
+            WeatherConnector,
+            GiphyConnector,
+            CurrencyConnector,
+            ReminderConnector,
+        )
+
+        return {
+            "schedule_meeting": CalendarConnector(),
+            "check_availability": CalendarConnector(),
+            "check_payments": ReadOnlyPaymentConnector(),
+            "search_info": SearchConnector(),
+            "get_weather": WeatherConnector(),
+            "search_gif": GiphyConnector(),
+            "convert_currency": CurrencyConnector(),
+            "send_message": WhatsAppConnector(),
+            "send_whatsapp": WhatsAppConnector(),
+            "send_email": GmailConnector(),
+            "set_reminder": ReminderConnector(),
+            "check_quotas": QuotaConnector(),
+            "check_balance": ReadOnlyPaymentConnector(),
+            "list_transactions": ReadOnlyPaymentConnector(),
+            "check_invoice_status": ReadOnlyPaymentConnector(),
+            "create_invoice": InvoiceConnector(),
+            "create_payment_link": IntersendPayConnector(),
+            "withdraw": IntersendPayConnector(),
+            "check_status": IntersendPayConnector(),
+            "search_buses": TravelBusesConnector(),
+            "search_hotels": TravelHotelsConnector(),
+            "search_flights": TravelFlightsConnector(),
+            "search_transfers": TravelTransfersConnector(),
+            "search_events": TravelEventsConnector(),
+            "create_itinerary": ItineraryConnector(),
+            "view_itinerary": ItineraryConnector(),
+            "add_to_itinerary": ItineraryConnector(),
+            "book_travel_item": ItineraryConnector(),
+        }
+    except Exception as exc:
+        logger.warning("Failed to load legacy connectors: %s", exc)
+        return {}
+
+
+def _scan_connectors_directory() -> list:
+    """
+    Scan Backend/orchestration/connectors/ for BaseConnector subclasses
+    that have the new-style `name` and `actions` attributes.
+    """
+    from orchestration.base_connector import BaseConnector
+
+    connectors = []
+    connectors_dir = Path(__file__).parent / "connectors"
+
+    if not connectors_dir.is_dir():
+        return connectors
+
+    for module_info in pkgutil.iter_modules([str(connectors_dir)]):
+        if module_info.name.startswith("_"):
+            continue
+        try:
+            module = importlib.import_module(
+                f"orchestration.connectors.{module_info.name}"
+            )
+        except Exception as exc:
+            logger.debug("Skipping connector module %s: %s", module_info.name, exc)
+            continue
+
+        for _attr_name, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(obj, BaseConnector)
+                and obj is not BaseConnector
+                and getattr(obj, "name", "")
+                and getattr(obj, "actions", [])
+            ):
+                try:
+                    instance = obj()
+                    connectors.append(instance)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to instantiate connector %s: %s",
+                        obj.__name__, exc,
+                    )
+
+    return connectors
+
+
+def _scan_examples_directory() -> list:
+    """Scan `<repo_root>/examples/connectors/*/` for BaseConnector subclasses.
+
+    Each example connector lives in its own subdirectory and ships at
+    least one `*_connector.py` file. Loaded via importlib.util so the
+    examples don't need to be on sys.path or installed as a package.
+    Only invoked when `is_demo_mode()` is true.
+    """
+    from orchestration.base_connector import BaseConnector
+
+    connectors: list = []
+    examples_root = _examples_connectors_root()
+    if examples_root is None:
+        logger.debug("Examples directory not found; skipping example scan.")
+        return connectors
+
+    for sub in sorted(p for p in examples_root.iterdir() if p.is_dir()):
+        if sub.name.startswith("_") or sub.name.startswith("."):
+            continue
+        for py_file in sorted(sub.glob("*_connector.py")):
+            module_name = f"kazi_examples_{sub.name}_{py_file.stem}"
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, py_file)
+                if spec is None or spec.loader is None:
+                    continue
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            except Exception as exc:
+                logger.warning("Skipping example %s/%s: %s", sub.name, py_file.name, exc)
+                continue
+
+            for _attr_name, obj in inspect.getmembers(module, inspect.isclass):
+                if (
+                    issubclass(obj, BaseConnector)
+                    and obj is not BaseConnector
+                    and getattr(obj, "name", "")
+                    and getattr(obj, "actions", [])
+                ):
+                    try:
+                        connectors.append(obj())
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to instantiate example connector %s: %s",
+                            obj.__name__, exc,
+                        )
+
+    return connectors
+
+
+def _scan_entry_points() -> list:
+    """
+    Discover pip-installed connectors via 'kazi.connectors' entry point group.
+
+    Community connectors register via pyproject.toml:
+        [project.entry-points."kazi.connectors"]
+        my_connector = "my_package:MyConnector"
+    """
+    from orchestration.base_connector import BaseConnector
+
+    connectors = []
+    try:
+        if hasattr(importlib.metadata, "entry_points"):
+            eps = importlib.metadata.entry_points()
+            # Python 3.12+ returns a SelectableGroups; 3.9-3.11 returns a dict
+            if isinstance(eps, dict):
+                group = eps.get("kazi.connectors", [])
+            else:
+                group = eps.select(group="kazi.connectors")
+            for ep in group:
+                try:
+                    cls = ep.load()
+                    if isinstance(cls, type) and issubclass(cls, BaseConnector):
+                        connectors.append(cls())
+                except Exception as exc:
+                    logger.warning("Failed to load entry point %s: %s", ep.name, exc)
+    except Exception as exc:
+        logger.debug("Entry point discovery unavailable: %s", exc)
+
+    return connectors

--- a/Backend/orchestration/contracts.py
+++ b/Backend/orchestration/contracts.py
@@ -1,8 +1,29 @@
-"""Shared result/event contracts for orchestration flows."""
+"""Shared result/event contracts for orchestration flows.
+
+Stable runtime contracts are documented under `docs/contracts/`. This
+module ships the in-tree builders + validators that back those docs.
+Each contract carries a Major.Minor version constant so consumers can
+pin against the surface they were tested against.
+"""
 from __future__ import annotations
 
+import re
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# Contract versions — bump on any change documented in docs/contracts/.
+CONNECTOR_EXECUTION_CONTRACT_VERSION = "1.1"
+TOOL_SCHEMA_CONTRACT_VERSION = "1.0"
+APPROVAL_CONTRACT_VERSION = "1.0"
+EXECUTION_DETAIL_CONTRACT_VERSION = "1.0"
+REPLAY_SAFETY_CONTRACT_VERSION = "1.0"
+
+
+_VALID_RISK_LEVELS = {"low", "medium", "high"}
+_VALID_PARAM_TYPES = {"string", "number", "integer", "boolean", "array", "object"}
+_VALID_CONFIRMATION_POLICIES = {"always", "high_risk", "never"}
+_ACTION_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 def build_orchestration_result(
@@ -35,6 +56,81 @@ def build_orchestration_result(
     if next_step:
         payload["next_step"] = next_step
     return payload
+
+
+def validate_catalog_entry(entry: Any) -> Tuple[bool, List[str]]:
+    """Validate a single tool-schema catalog entry against contract v1.0.
+
+    Returns (ok, errors). On any error the entry should be skipped by
+    the consumer (the connector registry logs the warning and moves on
+    so a single bad entry doesn't break boot). See
+    docs/contracts/tool-schema.md for the canonical shape.
+    """
+    errors: List[str] = []
+
+    if not isinstance(entry, dict):
+        return False, [f"entry is not a dict: {type(entry).__name__}"]
+
+    action = entry.get("action")
+    if not isinstance(action, str) or not action:
+        errors.append("missing or non-string 'action'")
+    elif not _ACTION_NAME_RE.match(action):
+        errors.append(f"action {action!r} must be snake_case (^[a-z][a-z0-9_]*$)")
+
+    service = entry.get("service")
+    if not isinstance(service, str) or not service:
+        errors.append("missing or non-string 'service'")
+
+    description = entry.get("description")
+    if not isinstance(description, str) or not description:
+        errors.append("missing or non-string 'description'")
+
+    risk_level = entry.get("risk_level")
+    if risk_level not in _VALID_RISK_LEVELS:
+        errors.append(f"risk_level {risk_level!r} not in {sorted(_VALID_RISK_LEVELS)}")
+
+    params = entry.get("params")
+    if not isinstance(params, dict):
+        errors.append("missing or non-dict 'params' (use {} for no-param actions)")
+    else:
+        for param_name, param_schema in params.items():
+            if not isinstance(param_schema, dict):
+                errors.append(f"params[{param_name!r}] is not a dict")
+                continue
+            ptype = param_schema.get("type")
+            if ptype is not None and ptype not in _VALID_PARAM_TYPES:
+                errors.append(
+                    f"params[{param_name!r}].type {ptype!r} not in {sorted(_VALID_PARAM_TYPES)}"
+                )
+            pdesc = param_schema.get("description")
+            if not isinstance(pdesc, str) or not pdesc:
+                errors.append(f"params[{param_name!r}] missing 'description'")
+
+    aliases = entry.get("aliases")
+    if aliases is not None and not (
+        isinstance(aliases, list) and all(isinstance(a, str) for a in aliases)
+    ):
+        errors.append("'aliases' must be a list of strings if provided")
+
+    confirmation_policy = entry.get("confirmation_policy")
+    if (
+        confirmation_policy is not None
+        and confirmation_policy not in _VALID_CONFIRMATION_POLICIES
+    ):
+        errors.append(
+            f"confirmation_policy {confirmation_policy!r} not in "
+            f"{sorted(_VALID_CONFIRMATION_POLICIES)}"
+        )
+
+    capability_gate = entry.get("capability_gate")
+    if capability_gate is not None and not isinstance(capability_gate, str):
+        errors.append("'capability_gate' must be a string if provided")
+
+    replay_safe = entry.get("replay_safe")
+    if replay_safe is not None and not isinstance(replay_safe, bool):
+        errors.append("'replay_safe' must be a bool if provided")
+
+    return (not errors), errors
 
 
 def build_step_event(


### PR DESCRIPTION
## Summary

**Phase 1** of the v0.4 OSS → master port. Brings the connector infrastructure that everything else depends on — with **zero runtime behavior change** on master. Every new symbol is callable but nothing on master currently invokes them. Phase 2 (M3 human-gated runtime) will be the first consumer.

Builds on top of #12 (Phase 0 whitespace normalize). With #12 merged, this PR diffs cleanly — no churn drowning the actual changes.

## What changes

| File | Change | Risk |
|---|---|---|
| `Backend/orchestration/base_connector.py` | Rewritten — barebones → public's v0.4 rich API (name/version/actions class attrs, validate_config, get_credential, get_action_catalog_entries) | Low — every existing master subclass already uses the modern `execute(parameters, context)` signature; the base's stale `(intent, user)` was being ignored everywhere |
| `Backend/orchestration/connector_registry.py` | NEW file — ported as-is from public | None — dormant; nothing calls `discover_connectors()` on master yet |
| `Backend/orchestration/action_catalog.py` | +`register_actions()` function (10th catalog function) | None — additive |
| `Backend/orchestration/contracts.py` | +5 version constants + `validate_catalog_entry()` | None — additive |

## Why now

Phase 0 (#12) normalized whitespace so this diff is readable. Now we land the foundation modules before the headline features that need them. Each subsequent phase reviews as a focused feature port, not "feature plus infrastructure plus refactor."

## What this PR does NOT do

- Doesn't wire `discover_connectors()` into `apps.py` startup (Phase 2)
- Doesn't refactor `mcp_router.py` to consume the registry (the M2-1 collapse — comes in Phase 3)
- Doesn't change how any existing connector executes
- Doesn't add demo mode / `KAZI_DEMO_MODE` (deliberately OSS-only)

## Verification

- [ ] `python -m compileall Backend` — clean
- [ ] `python -m flake8 ...` critical-correctness selectors — clean on new files
- [ ] `python Backend/manage.py check` — clean
- [ ] `python Backend/manage.py test` — full suite still green (no behavior change)

## Diff

`+637 / -11` across 4 files. Almost entirely additive (base_connector rewrite is the only "replace" and that surface was much thinner before).

## Next phases

- **Phase 2** — M3 human-gated runtime (workflows/runtime + migration + models + temporal_integration + views + admin + activity_executors registry fallback). The headline feature.
- **Phase 3** — kazi_trace CLI + M2-1 connector loading collapse + v0.4.1 bug fixes. Polish + foundation cleanup.
