### PR TITLE
feat(pentest): passive real OSINT tooling (slice 5C)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,10 @@ jobs:
         cd Backend
         python manage.py test --settings=Backend.settings_test
 
+    - name: Run agent unit tests
+      run: |
+        python -m unittest discover -s agents/kali_pentest_agent/tests -v
+
   build-and-deploy:
     needs: test
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')

--- a/Backend/pentest/agent_views.py
+++ b/Backend/pentest/agent_views.py
@@ -27,6 +27,13 @@ from pentest.execution import (
 )
 from pentest.models import PentestAgentHeartbeat, PentestExecutionJob, PentestLiveOutput
 
+# ---------------------------------------------------------------------------
+# Server-side size caps (5C — defense-in-depth)
+# ---------------------------------------------------------------------------
+
+MAX_MESSAGE_CHARS = 10_000  # output message max length
+MAX_RESULT_BYTES = 200_000  # complete result max serialized JSON size
+
 
 # ---------------------------------------------------------------------------
 # Base view with DRF overrides
@@ -189,6 +196,13 @@ class AgentOutputView(AgentBaseView):
             )
 
         message = data.get("message", "")
+        if not isinstance(message, str):
+            return Response(
+                {"error": "message must be a string"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if len(message) > MAX_MESSAGE_CHARS:
+            message = message[:MAX_MESSAGE_CHARS]
         event_id = data.get("event_id") or None
         if not isinstance(event_id, str) or not event_id.strip():
             return Response(
@@ -251,6 +265,22 @@ class AgentCompleteView(AgentBaseView):
             )
 
         result = data.get("result")
+        # Server-side size cap — reject oversized results before they reach the DB.
+        if result is not None:
+            import json as _json
+
+            try:
+                serialized = _json.dumps(result, ensure_ascii=False)
+            except (TypeError, ValueError):
+                return Response(
+                    {"error": "result is not JSON-serializable"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if len(serialized.encode("utf-8")) > MAX_RESULT_BYTES:
+                return Response(
+                    {"error": f"result exceeds maximum size ({MAX_RESULT_BYTES} bytes)"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
         complete_job(job, result=result)
         job.refresh_from_db()
         return Response(serialize_job(job))

--- a/Backend/pentest/execution.py
+++ b/Backend/pentest/execution.py
@@ -98,6 +98,19 @@ def create_execution_job(engagement: PentestEngagement, actor, *,
 
     requires_approval = definition.get("requires_approval", False)
 
+    # 1.5 — Passive shape validation (5C): passive actions must receive a bare
+    # DNS hostname, validated BEFORE ``enforce_engagement_scope`` normalizes it.
+    if definition.get("target_kind") == "domain":
+        from pentest.passive_validation import PassiveValidationError, validate_passive_target
+
+        try:
+            # Validate the RAW target (before scope resolver strips paths).
+            validated = validate_passive_target(target, action)
+        except PassiveValidationError as exc:
+            raise ExecutionError(str(exc))
+        # Use the canonicalized bare host for enforcement and the job row.
+        target = validated
+
     # 2. Enforcement chokepoint — must pass before anything else.
     d = enforce_engagement_scope(engagement, target)
     if not d.allowed:

--- a/Backend/pentest/execution_catalog.py
+++ b/Backend/pentest/execution_catalog.py
@@ -17,6 +17,36 @@ PENTEST_EXECUTION_ACTIONS: dict[str, dict] = {
         "requires_approval": True,
         "description": "Fake high-active scan used to test approval-gated execution.",
     },
+    # ------------------------------------------------------------------
+    # 5C — Passive real OSINT (no direct target-host contact)
+    # ------------------------------------------------------------------
+    "passive_dns_lookup": {
+        "category": "informational",
+        "catalog_risk_level": "low",
+        "requires_approval": False,
+        "transport": "agent",
+        "touches_target_host": False,
+        "target_kind": "domain",
+        "description": "Passive DNS record lookup through a resolver.",
+    },
+    "domain_rdap_lookup": {
+        "category": "informational",
+        "catalog_risk_level": "low",
+        "requires_approval": False,
+        "transport": "agent",
+        "touches_target_host": False,
+        "target_kind": "domain",
+        "description": "Collect registration/network metadata through RDAP bootstrap.",
+    },
+    "ct_subdomain_lookup": {
+        "category": "informational",
+        "catalog_risk_level": "low",
+        "requires_approval": False,
+        "transport": "agent",
+        "touches_target_host": False,
+        "target_kind": "domain",
+        "description": "Collect certificate-transparency names for a domain.",
+    },
 }
 
 

--- a/Backend/pentest/passive_validation.py
+++ b/Backend/pentest/passive_validation.py
@@ -1,0 +1,89 @@
+"""Passive target shape validation (5C).
+
+Every passive action must receive a bare DNS hostname — no URLs, no paths,
+no queries, no ports, no wildcards, no shell metacharacters.  This module
+validates the *raw submitted target* before ``scope.normalize_target``
+strips it, so path/query intent is never silently dropped.
+
+Uses an **allowlist** (valid DNS hostname syntax), not a denylist.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+class PassiveValidationError(ValueError):
+    """Raised when a target fails passive shape validation."""
+
+
+# DNS label: 1-63 chars, starts/ends with alphanumeric, internal hyphens ok.
+# RFC 952 / 1123 with the modern "may start with digit" relaxation.
+_LABEL_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$")
+
+# Overall hostname length limit (253 chars including dots).
+_MAX_HOSTNAME_LEN = 253
+_IPV4_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+
+def validate_passive_target(raw: str, action: str) -> str:
+    """Validate *raw* is a bare DNS hostname suitable for a passive action.
+
+    Returns the canonicalized hostname (lowercased, trailing dot stripped).
+    Raises ``PassiveValidationError`` on any violation.
+
+    Rules (allowlist only):
+    - Non-empty string.
+    - No scheme (``://``), no path, no query, no fragment, no port.
+    - No spaces, no wildcards (``*``).
+    - Each label 1-63 chars, alphanumeric + internal hyphens.
+    - Total length <= 253 chars.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        raise PassiveValidationError("target must be a non-empty string")
+
+    value = raw.strip()
+
+    # Reject anything that looks like a URL or has shell-ish characters.
+    if "://" in value:
+        raise PassiveValidationError(
+            f"URLs are not accepted for {action}; submit a bare domain"
+        )
+    if "?" in value or "#" in value:
+        raise PassiveValidationError(
+            f"paths/queries/fragments are not accepted for {action}"
+        )
+    if ":" in value:
+        raise PassiveValidationError(
+            f"ports are not accepted for {action}; submit a bare domain"
+        )
+    if " " in value or "\t" in value or "\n" in value:
+        raise PassiveValidationError("target must not contain whitespace")
+    if "*" in value:
+        raise PassiveValidationError("wildcards are not accepted for passive actions")
+
+    # Strip trailing dot (absolute DNS form) then validate.
+    host = value.lower().rstrip(".")
+    if not host:
+        raise PassiveValidationError("target must not be empty")
+
+    if len(host) > _MAX_HOSTNAME_LEN:
+        raise PassiveValidationError(
+            f"hostname too long ({len(host)} > {_MAX_HOSTNAME_LEN})"
+        )
+
+    labels = host.split(".")
+    if len(labels) < 2:
+        raise PassiveValidationError("target must be a fully-qualified domain name")
+    if _IPV4_RE.match(host):
+        raise PassiveValidationError("IP literals are not accepted for passive domain actions")
+
+    for label in labels:
+        if not _LABEL_RE.match(label):
+            raise PassiveValidationError(
+                f"invalid DNS label: {label!r}"
+            )
+    if labels[-1].isdigit():
+        raise PassiveValidationError("top-level domain must not be numeric")
+
+    return host

--- a/Backend/pentest/test_passive_tools.py
+++ b/Backend/pentest/test_passive_tools.py
@@ -1,0 +1,402 @@
+"""Passive tooling tests — real DB lane, hermetic (slice 5C).
+
+Charter:
+  P1. Catalog contains exactly the three passive actions with requires_approval=False.
+  P2. Passive action requires running + verified + in-scope engagement.
+  P3. Passive action rejects out-of-scope target.
+  P4. Passive action rejects URL/path/query/shell-like target — including an in-scope URL.
+  P5. Passive action does not require M3 approval.
+  P6. Unknown real-looking action rejected.
+  P7. Agent claim with passive capabilities claims only matching passive jobs.
+  P8. Capability stranding with passive actions.
+  P9. Server-side size cap: oversized result rejected (400).
+  P10. Server-side size cap: oversized message truncated.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from pentest.execution_catalog import PENTEST_EXECUTION_ACTIONS, get_execution_action
+from pentest.models import PentestEngagement, PentestExecutionJob
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+HERMETIC = override_settings(
+    CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}},
+)
+
+_SCOPE = {
+    "allow": [{"kind": "domain", "value": "example.com", "include_subdomains": True}],
+    "deny": [],
+}
+_AUTH_DATA = {
+    "auth_type": "signed_engagement",
+    "authorizer_name": "Acme",
+    "authorizer_contact": "sec@acme.test",
+    "evidence_ref": "SOW-001",
+}
+_PAYLOAD = {
+    "target": "example.com",
+    "scope_spec": _SCOPE,
+    "authorization": _AUTH_DATA,
+    "roe": {"notes": "Standard."},
+    "phases_enabled": ["recon"],
+}
+
+AGENT_TOKEN = "test-agent-shared-token-5c"
+AGENT_ID = "kali-dev-01"
+AGENT_HEADERS = {
+    "HTTP_AUTHORIZATION": f"Bearer {AGENT_TOKEN}",
+    "HTTP_X_PENTEST_AGENT_ID": AGENT_ID,
+}
+
+AGENT_SETTINGS = override_settings(
+    PENTEST_AGENT_ENABLED=True,
+    PENTEST_AGENT_SHARED_TOKEN=AGENT_TOKEN,
+    PENTEST_AGENT_ALLOWED_IDS=[AGENT_ID, "kali-dev-02"],
+)
+
+
+def _make_running_engagement(user):
+    import copy
+
+    c = APIClient()
+    c.force_authenticate(user=user)
+    data = copy.deepcopy(_PAYLOAD)
+    resp = c.post("/api/pentest/engagements/", data, format="json")
+    assert resp.status_code == 201, resp.content
+    eng_id = resp.data["engagement_id"]
+    eng = PentestEngagement.objects.get(engagement_id=eng_id, user=user)
+    resp = c.post(f"/api/pentest/engagements/{eng_id}/submit-authorization/")
+    assert resp.status_code == 200, resp.content
+    resp = c.post(f"/api/pentest/engagements/{eng_id}/verify/")
+    assert resp.status_code == 200, resp.content
+    resp = c.post(f"/api/pentest/engagements/{eng_id}/activate/")
+    assert resp.status_code == 200, resp.content
+    eng.refresh_from_db()
+    return eng, c
+
+
+def _queue_job(eng, user_client, action="passive_dns_lookup", target="app.example.com"):
+    resp = user_client.post(
+        f"/api/pentest/engagements/{eng.engagement_id}/jobs/",
+        {"action": action, "target": target},
+        format="json",
+    )
+    assert resp.status_code == 201, resp.content
+    return resp.data["job_id"]
+
+
+# ---------------------------------------------------------------------------
+# P1 — Catalog
+# ---------------------------------------------------------------------------
+
+
+@HERMETIC
+class CatalogTests(TestCase):
+    """P1, P5, P6: Catalog contains exactly the 5C passive actions."""
+
+    def test_catalog_contains_passive_actions(self):
+        passive = {k: v for k, v in PENTEST_EXECUTION_ACTIONS.items()
+                   if v.get("transport") == "agent" and v.get("touches_target_host") is False}
+        expected = {"passive_dns_lookup", "domain_rdap_lookup", "ct_subdomain_lookup"}
+        self.assertEqual(set(passive.keys()), expected)
+
+    def test_passive_actions_require_no_approval(self):
+        for action in ("passive_dns_lookup", "domain_rdap_lookup", "ct_subdomain_lookup"):
+            entry = get_execution_action(action)
+            self.assertIsNotNone(entry, f"{action} missing from catalog")
+            self.assertFalse(entry.get("requires_approval", True),
+                             f"{action} should not require approval")
+            self.assertEqual(entry.get("category"), "informational")
+            self.assertEqual(entry.get("target_kind"), "domain")
+
+    def test_disallowed_real_actions_rejected(self):
+        for action in ("http_head_probe", "nmap_scan", "nuclei_scan", "whois_shell"):
+            self.assertIsNone(get_execution_action(action),
+                              f"{action} must not be in the catalog")
+
+
+# ---------------------------------------------------------------------------
+# P2, P3, P4 — Target validation
+# ---------------------------------------------------------------------------
+
+
+@HERMETIC
+class PassiveTargetValidationTests(TestCase):
+    """P2–P4: Passive jobs still require enforcement + bare-host shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        User.objects.create_user(username="mathia", password="pw")
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="passive_val", password="pw")
+        self.eng, self.c = _make_running_engagement(self.user)
+        self.jobs_url = f"/api/pentest/engagements/{self.eng.engagement_id}/jobs/"
+
+    # P2
+    def test_passive_action_requires_running_engagement(self):
+        self.eng.status = "draft"
+        self.eng.save()
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "app.example.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    # P3
+    def test_passive_action_rejects_out_of_scope(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "other.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    # P4 — URL target rejected
+    def test_passive_action_rejects_url_target(self):
+        for bad in (
+            "https://app.example.com/admin?x=1",
+            "http://app.example.com/path",
+            "app.example.com:443",
+            "app.example.com?x=1",
+            "app.example.com#frag",
+            "*.example.com",
+            "app.exa mple.com",
+            "localhost",
+            "127.0.0.1",
+            "app.example.123",
+            "app..example.com",
+            "app.example.com/path",
+            "app.example.com;whoami",
+        ):
+            resp = self.c.post(self.jobs_url, {
+                "action": "passive_dns_lookup", "target": bad,
+            }, format="json")
+            self.assertEqual(resp.status_code, 400,
+                             f"target {bad!r} should be rejected but got {resp.status_code}: {resp.content}")
+
+    # P4 extended — in-scope URL where host matches but shape is rejected
+    def test_passive_action_rejects_in_scope_url(self):
+        """An in-scope URL like https://app.example.com/x is in scope by host,
+        but the URL shape must be rejected up front before normalization strips it."""
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup",
+            "target": "https://app.example.com/x?y=1",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_validator_rejects_ip_even_when_in_cidr_scope(self):
+        """Isolates the validator's IPv4 rejection from enforcement.
+
+        With a CIDR scope, an IP target is IN SCOPE — so enforcement would
+        allow it. Only the passive validator (bare-domain only) can reject it.
+        Fails if the IPv4 check is removed (job would be created).
+        """
+        self.eng.scope_spec = {"allow": [{"kind": "cidr", "value": "10.0.0.0/8"}], "deny": []}
+        self.eng.save()
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "10.1.2.3",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_validator_rejects_numeric_tld_even_when_in_scope(self):
+        """Isolates the validator's numeric-TLD rejection from enforcement.
+
+        The scope explicitly allows the numeric-TLD host, so enforcement would
+        allow it; only the validator rejects it. Fails if the numeric-TLD check
+        is removed.
+        """
+        self.eng.scope_spec = {
+            "allow": [{"kind": "host", "value": "example.55"}], "deny": []}
+        self.eng.save()
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "example.55",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_validator_rejects_single_label_even_when_in_scope(self):
+        """Isolates the validator's FQDN (>=2 labels) rejection from enforcement."""
+        self.eng.scope_spec = {
+            "allow": [{"kind": "host", "value": "intranet"}], "deny": []}
+        self.eng.save()
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "intranet",
+        }, format="json")
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_passive_action_accepts_bare_domain(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "app.example.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertEqual(resp.data["status"], "queued")
+
+    def test_passive_action_accepts_bare_domain_with_trailing_dot(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "app.example.com.",
+        }, format="json")
+        self.assertEqual(resp.status_code, 201, resp.content)
+
+    # P5 — no approval needed (tested via successful creation without approval_id)
+    def test_passive_dns_no_approval_needed(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "passive_dns_lookup", "target": "app.example.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 201)
+
+    def test_rdap_no_approval_needed(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "domain_rdap_lookup", "target": "app.example.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 201)
+
+    def test_ct_no_approval_needed(self):
+        resp = self.c.post(self.jobs_url, {
+            "action": "ct_subdomain_lookup", "target": "app.example.com",
+        }, format="json")
+        self.assertEqual(resp.status_code, 201)
+
+
+# ---------------------------------------------------------------------------
+# P7, P8 — Agent claim with passive capabilities
+# ---------------------------------------------------------------------------
+
+
+@HERMETIC
+@AGENT_SETTINGS
+class PassiveClaimTests(TestCase):
+    """P7–P8: Agent capabilities gate passive jobs."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        User.objects.create_user(username="mathia", password="pw")
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="pclaim_op", password="pw")
+        self.eng, self.user_client = _make_running_engagement(self.user)
+        self.agent_client = APIClient()
+
+    def test_claim_with_passive_caps_claims_passive_job(self):
+        _queue_job(self.eng, self.user_client, action="passive_dns_lookup")
+        resp = self.agent_client.post(
+            "/api/pentest/agent/v1/jobs/claim/",
+            {"capabilities": ["passive_dns_lookup", "domain_rdap_lookup"]},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["status"], "claimed")
+        self.assertEqual(resp.data["job"]["action"], "passive_dns_lookup")
+
+    def test_passive_caps_do_not_claim_fake_job(self):
+        _queue_job(self.eng, self.user_client, action="fake_dns_lookup")
+        resp = self.agent_client.post(
+            "/api/pentest/agent/v1/jobs/claim/",
+            {"capabilities": ["passive_dns_lookup"]},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.data["status"], "idle")
+        job = PentestExecutionJob.objects.filter(
+            engagement=self.eng, action="fake_dns_lookup"
+        ).first()
+        self.assertEqual(job.status, "queued")
+
+    def test_missing_capabilities_cannot_claim_globally(self):
+        _queue_job(self.eng, self.user_client, action="passive_dns_lookup")
+        resp = self.agent_client.post(
+            "/api/pentest/agent/v1/jobs/claim/",
+            {"capabilities": ["some_nonexistent_action"]},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.data["status"], "idle")
+
+
+# ---------------------------------------------------------------------------
+# P9, P10 — Server-side size caps
+# ---------------------------------------------------------------------------
+
+
+@HERMETIC
+@AGENT_SETTINGS
+class SizeCapTests(TestCase):
+    """P9–P10: Server-side result/message size limits."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        User.objects.create_user(username="mathia", password="pw")
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="cap_op", password="pw")
+        self.eng, self.user_client = _make_running_engagement(self.user)
+        self.agent_client = APIClient()
+        self.job_id = _queue_job(self.eng, self.user_client, action="passive_dns_lookup")
+        # Claim
+        resp = self.agent_client.post(
+            "/api/pentest/agent/v1/jobs/claim/",
+            {"capabilities": ["passive_dns_lookup"]},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.data["status"], "claimed")
+
+    def test_oversized_result_rejected(self):
+        # Build a result > 200k bytes
+        big = {"data": "x" * 200_000}
+        resp = self.agent_client.post(
+            f"/api/pentest/agent/v1/jobs/{self.job_id}/complete/",
+            {"result": big},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.assertIn("exceeds maximum size", str(resp.data.get("error", "")))
+
+    def test_oversized_message_truncated(self):
+        big_msg = "A" * 15_000
+        # Must mark running first (output requires running status).
+        resp_run = self.agent_client.post(
+            f"/api/pentest/agent/v1/jobs/{self.job_id}/running/",
+            {},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp_run.status_code, 200, resp_run.content)
+        resp = self.agent_client.post(
+            f"/api/pentest/agent/v1/jobs/{self.job_id}/output/",
+            {"event_id": f"{AGENT_ID}:{self.job_id}:1", "sequence": 1,
+             "level": "info", "message": big_msg},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.status_code, 201)
+        # The message should have been truncated
+        from pentest.models import PentestLiveOutput
+        output = PentestLiveOutput.objects.filter(
+            agent_event_id=f"{AGENT_ID}:{self.job_id}:1"
+        ).first()
+        self.assertIsNotNone(output)
+        self.assertLessEqual(len(output.message), 10_000)
+
+    def test_non_string_output_message_rejected(self):
+        resp_run = self.agent_client.post(
+            f"/api/pentest/agent/v1/jobs/{self.job_id}/running/",
+            {},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp_run.status_code, 200, resp_run.content)
+        resp = self.agent_client.post(
+            f"/api/pentest/agent/v1/jobs/{self.job_id}/output/",
+            {"event_id": f"{AGENT_ID}:{self.job_id}:msg", "sequence": 1,
+             "level": "info", "message": {"not": "a string"}},
+            format="json",
+            **AGENT_HEADERS,
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("message", str(resp.data.get("error", "")))

--- a/agents/kali_pentest_agent/README.md
+++ b/agents/kali_pentest_agent/README.md
@@ -1,7 +1,7 @@
-# Kali Pentest Agent (5B)
+# Kali Pentest Agent (5C)
 
 Separate process that polls the Django pentest agent API for queued
-execution jobs and runs them with **fake deterministic runners only**.
+execution jobs and runs them through a strict allowlist.
 
 ## Quickstart
 
@@ -21,15 +21,48 @@ python -c "from agents.kali_pentest_agent.worker import run_once; print(run_once
 uvicorn agents.kali_pentest_agent.main:app --host 0.0.0.0 --port 9001
 ```
 
+## How it fits
+
+Django (`PentestExecutionJob`) is the authoritative queue. A job is only created after
+the full safety spine passes — running + admin-verified engagement, scope enforcement,
+M3 approval gates (for high-active actions), and (for passive actions) bare-domain shape
+validation. This agent authenticates, claims a job by capability, runs the matching
+collector, posts job-correlated/idempotent output, and completes with a normalized result.
+The agent never decides *what* to run — it only executes server-allowlisted actions.
+
 ## Endpoints
 
-- `GET /healthz` — local agent health
-- `POST /run-once` — trigger one poll cycle against Django
+- `GET /healthz` — local agent health (no Django dependency)
+- `POST /run-once` — trigger one poll cycle against Django (dev/smoke only; never expose
+  publicly without its own auth; accepts no action/target input)
+
+## Passive actions (5C)
+
+Real OSINT, **no direct contact with the target host** — every collector talks only to a
+DNS resolver or a fixed third-party provider; the target is only ever a validated bare
+domain used as an encoded query parameter. Every HTTP call uses a timeout + TLS verification.
+
+| Action | Provider | Returns |
+| --- | --- | --- |
+| `passive_dns_lookup` | configured DNS resolver | A/AAAA/CNAME/MX/TXT/NS records |
+| `domain_rdap_lookup` | RDAP bootstrap (ARIN) | registration/network metadata |
+| `ct_subdomain_lookup` | crt.sh | certificate-transparency names (capped, deduped) |
+
+Note: `passive_dns_lookup` is *live recursive resolution* via a resolver — the agent opens
+no socket to the target's services, but the target's authoritative nameserver does receive
+the query. That is expected for an authorized, in-scope engagement.
+
+Results are normalized (`action`/`target`/`method`/`source`/`collected_at`/`errors` plus
+action-specific keys) and bounded in size; provider failures become partial results with
+`errors` rather than a hard failure.
 
 ## Safety
 
-- Only `fake_dns_lookup` and `fake_nuclei_scan` are supported.
-- No subprocess, shell, DNS, or network calls to targets.
+- Supported actions are `fake_dns_lookup`, `fake_nuclei_scan`, `passive_dns_lookup`,
+  `domain_rdap_lookup`, and `ct_subdomain_lookup`.
+- No subprocess, shell, direct target HTTP/TLS sockets, scans, crawling, or exploit actions.
+- Passive collectors may query DNS resolvers or fixed provider endpoints such as RDAP/CT
+  sources; target values are validated bare domains and are not used as arbitrary URLs.
 - Unknown actions are rejected.
 - Token is never logged.
 
@@ -37,5 +70,5 @@ uvicorn agents.kali_pentest_agent.main:app --host 0.0.0.0 --port 9001
 
 The agent sends a shared token via `Authorization: Bearer <token>`
 and an agent ID via `X-Pentest-Agent-Id`.  Django validates both.
-This is suitable for 5B (fake runners only).  Per-agent credentials
+This is suitable for 5C. Per-agent credentials
 (mTLS/HMAC) are required before 5D real execution.

--- a/agents/kali_pentest_agent/passive_collectors.py
+++ b/agents/kali_pentest_agent/passive_collectors.py
@@ -1,0 +1,297 @@
+"""Passive OSINT collectors (5C) — real intelligence, no target-host contact.
+
+Each collector returns (outputs, result) where:
+- ``outputs`` are agent output event dicts WITHOUT event IDs (added by runners.py).
+- ``result`` is the final normalized result dict.
+
+Collectors call third-party/provider services only, never the target host itself.
+Every request uses ``timeout`` + ``verify=True``; the target is only ever an
+encoded query parameter.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+from datetime import datetime, timezone
+
+import dns.resolver
+import requests
+
+# ---------------------------------------------------------------------------
+# Network safety constants
+# ---------------------------------------------------------------------------
+
+REQUEST_TIMEOUT_SECONDS = 10
+MAX_CT_NAMES = 100
+MAX_OUTPUT_EVENTS = 25
+MAX_RESULT_BYTES = 200_000
+MAX_REDIRECTS = 5
+
+# Hardcoded provider hosts — the target is never the host/scheme/path.
+CT_BASE = "https://crt.sh"  # nosemgrep: hardcoded-url-ct-source
+RDAP_BOOTSTRAP_BASE = "https://rdap-bootstrap.arin.net/bootstrap"  # nosemgrep: hardcoded-url-rdap-bootstrap
+
+# Common record types for passive DNS.
+DNS_RECORD_TYPES = ["A", "AAAA", "CNAME", "MX", "TXT", "NS"]
+_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+_IPV4_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_bare_host(target: str, action: str) -> str:
+    """Re-validate *target* is a bare host before any network call.
+
+    Cheap defense-in-depth — stops a bad job from reaching the network even
+    if a future server-side bug lets a malformed target through.
+    """
+    if not target or not isinstance(target, str):
+        raise ValueError(f"target must be a non-empty string for {action}")
+    t = target.strip().lower().rstrip(".")
+    if not t:
+        raise ValueError(f"target must not be empty for {action}")
+    if "://" in t or "?" in t or "#" in t or ":" in t or "/" in t or "\\" in t:
+        raise ValueError(f"target must be a bare host for {action}, got {target!r}")
+    if any(ch in t for ch in (" ", "\t", "\n", "*", "@", "&", "|", ";", "<", ">", "`", "$", "(", ")", "{", "}", "[", "]", ",")):
+        raise ValueError(f"target contains invalid characters for {action}")
+    labels = t.split(".")
+    if len(labels) < 2:
+        raise ValueError(f"target must be a fully-qualified domain name for {action}")
+    if _IPV4_RE.match(t):
+        raise ValueError(f"IP literals are not accepted for {action}")
+    for label in labels:
+        if not _LABEL_RE.match(label):
+            raise ValueError(f"invalid DNS label {label!r} for {action}")
+    if labels[-1].isdigit():
+        raise ValueError(f"top-level domain must not be numeric for {action}")
+    return t
+
+
+def _base_result(action: str, target: str) -> dict:
+    return {
+        "action": action,
+        "target": target,
+        "method": "passive",
+        "source": "",
+        "collected_at": _now_iso(),
+        "errors": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Passive DNS
+# ---------------------------------------------------------------------------
+
+
+def collect_passive_dns(target: str) -> tuple[list[dict], dict]:
+    """Collect A/AAAA/CNAME/MX/TXT/NS records via a configured resolver.
+
+    The agent opens no socket to the target's services. The target's
+    authoritative nameserver does receive the query — that is fine for an
+    authorized, in-scope engagement.
+    """
+    domain = _validate_bare_host(target, "passive_dns_lookup")
+    result = _base_result("passive_dns_lookup", domain)
+    result["source"] = "system_resolver"
+    result["records"] = {}
+    outputs: list[dict] = []
+
+    outputs.append({
+        "level": "info",
+        "message": f"Resolving DNS records for {domain}...",
+    })
+
+    resolver = dns.resolver.Resolver()
+    resolver.timeout = REQUEST_TIMEOUT_SECONDS
+    resolver.lifetime = REQUEST_TIMEOUT_SECONDS
+
+    for rtype in DNS_RECORD_TYPES:
+        try:
+            answers = resolver.resolve(domain, rtype)  # nosec BXXX - target is validated
+            result["records"][rtype] = [str(a) for a in answers]
+        except dns.exception.DNSException as exc:
+            result["errors"].append(f"{rtype}: {exc.__class__.__name__}")
+        except Exception as exc:
+            result["errors"].append(f"{rtype}: {exc!r}")
+
+    record_count = sum(len(v) for v in result["records"].values())
+    outputs.append({
+        "level": "success",
+        "message": f"DNS lookup complete: {record_count} record(s) across {len(result['records'])} type(s)",
+    })
+    return outputs, _truncate_result(result)
+
+
+# ---------------------------------------------------------------------------
+# RDAP
+# ---------------------------------------------------------------------------
+
+
+def collect_domain_rdap(target: str) -> tuple[list[dict], dict]:
+    """Collect domain registration metadata through RDAP bootstrap.
+
+    Domain targets only — RDAP for IPs is deferred.
+    """
+    domain = _validate_bare_host(target, "domain_rdap_lookup")
+    result = _base_result("domain_rdap_lookup", domain)
+    result["source"] = "rdap_bootstrap"
+    result["rdap"] = {}
+    outputs: list[dict] = []
+
+    outputs.append({
+        "level": "info",
+        "message": f"Querying RDAP for {domain}...",
+    })
+
+    try:
+        # Step 1: Bootstrap to find the authoritative RDAP server.
+        bootstrap_url = f"{RDAP_BOOTSTRAP_BASE}/domain/{urllib.parse.quote(domain)}"  # nosemgrep: url-encode-target
+        resp = requests.get(
+            bootstrap_url,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            verify=True,  # nosec B501 — TLS is required
+            allow_redirects=True,
+        )
+        resp.raise_for_status()
+        redirect_count = len(resp.history)
+        if redirect_count > MAX_REDIRECTS:
+            result["errors"].append(f"excessive redirects ({redirect_count})")
+            outputs.append({
+                "level": "warning",
+                "message": f"RDAP bootstrap redirected {redirect_count} times — result may be incomplete",
+            })
+        result["rdap"] = _safe_truncate_json(resp.json(), "rdap")
+    except requests.RequestException as exc:
+        result["errors"].append(f"rdap_request: {exc!r}")
+        outputs.append({
+            "level": "warning",
+            "message": f"RDAP query failed: {exc!r}",
+        })
+
+    outputs.append({
+        "level": "success",
+        "message": "RDAP lookup complete",
+    })
+    return outputs, _truncate_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Certificate Transparency
+# ---------------------------------------------------------------------------
+
+
+def collect_ct_subdomains(target: str) -> tuple[list[dict], dict]:
+    """Collect certificate-transparency names for a domain via crt.sh.
+
+    The target appears only as an encoded query parameter.
+    """
+    domain = _validate_bare_host(target, "ct_subdomain_lookup")
+    result = _base_result("ct_subdomain_lookup", domain)
+    result["source"] = "crt.sh"
+    result["names"] = []
+    outputs: list[dict] = []
+
+    outputs.append({
+        "level": "info",
+        "message": f"Querying CT logs for {domain}...",
+    })
+
+    try:
+        # Target goes into query param only, URL-encoded.
+        ct_url = f"{CT_BASE}/?q={urllib.parse.quote(domain)}&output=json"  # nosemgrep: url-encode-target
+        resp = requests.get(
+            ct_url,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            verify=True,  # nosec B501 — TLS is required
+            allow_redirects=False,  # do not follow off-host redirects
+        )
+        resp.raise_for_status()
+        entries = resp.json()
+
+        names: set[str] = set()
+        for entry in entries:
+            name_value = (entry.get("name_value") or "").strip()
+            if name_value:
+                # crt.sh returns newline-separated names per entry.
+                for name in name_value.split("\n"):
+                    name = name.strip().lower().rstrip(".")
+                    if name and not name.startswith("*."):
+                        names.add(name)
+            if len(names) >= MAX_CT_NAMES:
+                break
+
+        result["names"] = sorted(names)[:MAX_CT_NAMES]
+    except requests.RequestException as exc:
+        result["errors"].append(f"ct_request: {exc!r}")
+        outputs.append({
+            "level": "warning",
+            "message": f"CT query failed: {exc!r}",
+        })
+    except (json.JSONDecodeError, TypeError) as exc:
+        result["errors"].append(f"ct_parse: {exc!r}")
+        outputs.append({
+            "level": "warning",
+            "message": f"CT response could not be parsed: {exc!r}",
+        })
+
+    outputs.append({
+        "level": "success",
+        "message": f"CT lookup complete: {len(result['names'])} name(s)",
+    })
+    return outputs, _truncate_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Internal
+# ---------------------------------------------------------------------------
+
+
+def _truncate_result(result: dict) -> dict:
+    """Ensure result JSON does not exceed MAX_RESULT_BYTES."""
+    serialized = json.dumps(result, ensure_ascii=False)
+    if len(serialized.encode("utf-8")) <= MAX_RESULT_BYTES:
+        return result
+    # Truncate the largest fields progressively.
+    for key in ("records", "rdap", "names"):
+        if key in result:
+            result[key] = _halve_collection(result[key])
+            serialized = json.dumps(result, ensure_ascii=False)
+            if len(serialized.encode("utf-8")) <= MAX_RESULT_BYTES:
+                return result
+    # Last resort: drop large data fields.
+    if "records" in result:
+        result["records"] = {}
+    if "rdap" in result:
+        result["rdap"] = {}
+    if "names" in result:
+        result["names"] = []
+    result["errors"].append("result truncated to fit MAX_RESULT_BYTES")
+    return result
+
+
+def _halve_collection(value):
+    if isinstance(value, list):
+        return value[: max(1, len(value) // 2)]
+    if isinstance(value, dict):
+        items = list(value.items())[: max(1, len(value) // 2)]
+        return dict(items)
+    return value
+
+
+def _safe_truncate_json(data: dict, label: str) -> dict:
+    """Return *data* or a truncated placeholder if it's too large."""
+    try:
+        serialized = json.dumps(data, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return {"error": f"RDAP response not JSON-serializable"}
+    if len(serialized.encode("utf-8")) > MAX_RESULT_BYTES // 2:
+        return {"truncated": True, "label": label, "size_bytes": len(serialized.encode("utf-8"))}
+    return data

--- a/agents/kali_pentest_agent/requirements.txt
+++ b/agents/kali_pentest_agent/requirements.txt
@@ -5,3 +5,4 @@
 fastapi>=0.100.0
 uvicorn[standard]>=0.23.0
 requests>=2.31.0
+dnspython>=2.6.0

--- a/agents/kali_pentest_agent/runners.py
+++ b/agents/kali_pentest_agent/runners.py
@@ -6,7 +6,13 @@ Any unknown action must be rejected.
 
 from __future__ import annotations
 
-SUPPORTED_ACTIONS = {"fake_dns_lookup", "fake_nuclei_scan"}
+SUPPORTED_ACTIONS = {
+    "fake_dns_lookup",
+    "fake_nuclei_scan",
+    "passive_dns_lookup",
+    "domain_rdap_lookup",
+    "ct_subdomain_lookup",
+}
 
 
 class UnknownActionError(ValueError):
@@ -81,14 +87,52 @@ def run_fake_nuclei_scan(job: dict) -> tuple[list[dict], dict]:
     return outputs, result
 
 
+def _make_passive_runner(action: str):
+    """Return a runner that calls the passive collector and stamps event IDs."""
+
+    def runner(job: dict) -> tuple[list[dict], dict]:
+        from .passive_collectors import (
+            collect_passive_dns,
+            collect_domain_rdap,
+            collect_ct_subdomains,
+        )
+
+        _collectors = {
+            "passive_dns_lookup": collect_passive_dns,
+            "domain_rdap_lookup": collect_domain_rdap,
+            "ct_subdomain_lookup": collect_ct_subdomains,
+        }
+        collector = _collectors[action]
+        job_id = job["job_id"]
+        target = job.get("target", "")
+        agent_id = _agent_id()
+
+        outputs, result = collector(target)
+
+        # Stamp deterministic event IDs.
+        stamped = []
+        for i, ev in enumerate(outputs, start=1):
+            stamped.append({
+                **ev,
+                "event_id": f"{agent_id}:{job_id}:{i}",
+                "sequence": i,
+            })
+        return stamped, result
+
+    return runner
+
+
 _RUNNERS = {
     "fake_dns_lookup": run_fake_dns_lookup,
     "fake_nuclei_scan": run_fake_nuclei_scan,
+    "passive_dns_lookup": _make_passive_runner("passive_dns_lookup"),
+    "domain_rdap_lookup": _make_passive_runner("domain_rdap_lookup"),
+    "ct_subdomain_lookup": _make_passive_runner("ct_subdomain_lookup"),
 }
 
 
 def dispatch(job: dict) -> tuple[list[dict], dict]:
-    """Dispatch *job* to the correct fake runner by action.
+    """Dispatch *job* to the correct runner by action.
 
     Returns (outputs, result).
     Raises ``UnknownActionError`` for unsupported actions.

--- a/agents/kali_pentest_agent/tests/test_passive_collectors.py
+++ b/agents/kali_pentest_agent/tests/test_passive_collectors.py
@@ -1,0 +1,217 @@
+"""Passive collector tests — ZERO real network, all mocked (5C)."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+os.environ.setdefault("PENTEST_AGENT_ID", "kali-test-01")
+os.environ.setdefault("PENTEST_AGENT_TOKEN", "test-token")
+os.environ.setdefault("PENTEST_AGENT_API_BASE", "http://localhost:8000/api/pentest/agent/v1")
+
+from agents.kali_pentest_agent.runners import (
+    SUPPORTED_ACTIONS,
+    UnknownActionError,
+    dispatch,
+)
+
+
+class SupportedActionsTests(unittest.TestCase):
+    """SUPPORTED_ACTIONS includes passive and no probes."""
+
+    def test_passive_actions_present(self):
+        for action in ("passive_dns_lookup", "domain_rdap_lookup", "ct_subdomain_lookup"):
+            self.assertIn(action, SUPPORTED_ACTIONS)
+
+    def test_no_direct_probe_actions(self):
+        for bad in ("http_head_probe", "nmap_scan", "nuclei_scan", "whois_shell"):
+            self.assertNotIn(bad, SUPPORTED_ACTIONS)
+
+
+class PassiveDnsCollectorTests(unittest.TestCase):
+    """Passive DNS: mocked resolver, asserts domain passed."""
+
+    def test_returns_normalized_result_shape(self):
+        with patch("dns.resolver.Resolver.resolve") as mock_resolve:
+            mock_answers = MagicMock()
+            mock_answers.__iter__.return_value = [MagicMock(__str__=lambda s: "203.0.113.10")]
+            mock_resolve.return_value = mock_answers
+
+            from agents.kali_pentest_agent.passive_collectors import collect_passive_dns
+
+            outputs, result = collect_passive_dns("example.com")
+
+            domains_called = {c.args[0] for c in mock_resolve.call_args_list}
+            self.assertIn("example.com", domains_called)
+            self.assertEqual(result["action"], "passive_dns_lookup")
+            self.assertEqual(result["target"], "example.com")
+            self.assertEqual(result["method"], "passive")
+            self.assertEqual(result["source"], "system_resolver")
+            self.assertIn("records", result)
+            self.assertIn("collected_at", result)
+            self.assertIn("errors", result)
+            self.assertIsInstance(outputs, list)
+            self.assertGreaterEqual(len(outputs), 2)
+
+    def test_bare_host_rejected_on_non_bare_target(self):
+        from agents.kali_pentest_agent.passive_collectors import collect_passive_dns
+
+        for bad in (
+            "https://example.com/path",
+            "example.com/path",
+            "localhost",
+            "127.0.0.1",
+            "example.123",
+            "example.com;whoami",
+        ):
+            with self.subTest(target=bad):
+                with self.assertRaises(ValueError):
+                    collect_passive_dns(bad)
+
+
+class RdapCollectorTests(unittest.TestCase):
+    """RDAP: mock requests.get; assert URL host is provider, not target."""
+
+    def test_url_host_is_rdap_provider_not_target(self):
+        def check_url(url, **kwargs):
+            self.assertIn("rdap-bootstrap.arin.net", url,
+                          f"URL host must be RDAP provider, got: {url}")
+            self.assertNotIn("example.com", url.split("://")[1].split("/")[0],
+                             "Target must not be the URL host")
+            resp = MagicMock()
+            resp.json.return_value = {"objectClassName": "domain"}
+            resp.history = [MagicMock()]
+            resp.raise_for_status.return_value = None
+            return resp
+
+        with patch("requests.get", side_effect=check_url):
+            from agents.kali_pentest_agent.passive_collectors import collect_domain_rdap
+
+            outputs, result = collect_domain_rdap("example.com")
+            self.assertEqual(result["action"], "domain_rdap_lookup")
+            self.assertEqual(result["target"], "example.com")
+
+    def test_provider_error_returns_result_with_errors(self):
+        with patch("requests.get", side_effect=requests.RequestException("network error")):
+            from agents.kali_pentest_agent.passive_collectors import collect_domain_rdap
+
+            outputs, result = collect_domain_rdap("example.com")
+            self.assertEqual(result["action"], "domain_rdap_lookup")
+            self.assertGreater(len(result["errors"]), 0)
+
+
+class CtCollectorTests(unittest.TestCase):
+    """CT: mock requests.get; assert URL host is CT provider, not target."""
+
+    def test_url_host_is_ct_provider_not_target(self):
+        def check_url(url, **kwargs):
+            self.assertIn("crt.sh", url,
+                          f"URL host must be CT provider, got: {url}")
+            self.assertNotIn("example.com", url.split("://")[1].split("/")[0],
+                             "Target must not be the URL host")
+            resp = MagicMock()
+            resp.json.return_value = [
+                {"name_value": "www.example.com\napi.example.com"},
+            ]
+            resp.raise_for_status.return_value = None
+            return resp
+
+        with patch("requests.get", side_effect=check_url):
+            from agents.kali_pentest_agent.passive_collectors import collect_ct_subdomains
+
+            outputs, result = collect_ct_subdomains("example.com")
+            self.assertEqual(result["action"], "ct_subdomain_lookup")
+            self.assertEqual(result["target"], "example.com")
+            self.assertEqual(result["source"], "crt.sh")
+            self.assertIn("www.example.com", result["names"])
+            self.assertIn("api.example.com", result["names"])
+
+    def test_caps_and_deduplicates_names(self):
+        def check_url(url, **kwargs):
+            resp = MagicMock()
+            resp.json.return_value = [
+                {"name_value": "a.example.com\nb.example.com\na.example.com"},
+                {"name_value": "c.example.com"},
+            ] * 100
+            resp.raise_for_status.return_value = None
+            return resp
+
+        with patch("requests.get", side_effect=check_url):
+            from agents.kali_pentest_agent.passive_collectors import collect_ct_subdomains
+
+            outputs, result = collect_ct_subdomains("example.com")
+            self.assertEqual(len(result["names"]), 3)
+            self.assertEqual(set(result["names"]), {"a.example.com", "b.example.com", "c.example.com"})
+
+    def test_provider_timeout_returns_result_with_errors(self):
+        with patch("requests.get", side_effect=requests.RequestException("timeout")):
+            from agents.kali_pentest_agent.passive_collectors import collect_ct_subdomains
+
+            outputs, result = collect_ct_subdomains("example.com")
+            self.assertGreater(len(result["errors"]), 0)
+            self.assertEqual(result["names"], [])
+
+    def test_result_truncation_handles_dict_fields(self):
+        from agents.kali_pentest_agent import passive_collectors as pc
+
+        result = {
+            "action": "domain_rdap_lookup",
+            "target": "example.com",
+            "method": "passive",
+            "source": "rdap_bootstrap",
+            "collected_at": "2026-06-28T00:00:00+00:00",
+            "errors": [],
+            "rdap": {f"k{i}": "x" * 100 for i in range(500)},
+        }
+        with patch.object(pc, "MAX_RESULT_BYTES", 1000):
+            truncated = pc._truncate_result(result)
+        self.assertIsInstance(truncated["rdap"], dict)
+        self.assertLessEqual(len(truncated["rdap"]), 250)
+
+
+class DispatchTests(unittest.TestCase):
+    """Dispatch routes passive actions to collectors."""
+
+    def test_dispatch_routes_passive_dns(self):
+        job = {"job_id": "j1", "action": "passive_dns_lookup", "target": "example.com", "params": {}}
+        with patch("agents.kali_pentest_agent.passive_collectors.collect_passive_dns") as mock_c:
+            mock_c.return_value = (
+                [{"level": "info", "message": "ok"}],
+                {"action": "passive_dns_lookup", "target": "example.com"},
+            )
+            outputs, result = dispatch(job)
+            mock_c.assert_called_once_with("example.com")
+            self.assertEqual(outputs[0]["event_id"], "kali-test-01:j1:1")
+            self.assertEqual(outputs[0]["sequence"], 1)
+
+    def test_dispatch_routes_rdap(self):
+        job = {"job_id": "j2", "action": "domain_rdap_lookup", "target": "example.com", "params": {}}
+        with patch("agents.kali_pentest_agent.passive_collectors.collect_domain_rdap") as mock_c:
+            mock_c.return_value = ([], {"action": "domain_rdap_lookup"})
+            _, result = dispatch(job)
+            mock_c.assert_called_once_with("example.com")
+
+    def test_dispatch_routes_ct(self):
+        job = {"job_id": "j3", "action": "ct_subdomain_lookup", "target": "example.com", "params": {}}
+        with patch("agents.kali_pentest_agent.passive_collectors.collect_ct_subdomains") as mock_c:
+            mock_c.return_value = ([], {"action": "ct_subdomain_lookup"})
+            _, result = dispatch(job)
+            mock_c.assert_called_once_with("example.com")
+
+    def test_unknown_real_action_raises(self):
+        job = {"job_id": "j4", "action": "http_head_probe", "target": "example.com", "params": {}}
+        with self.assertRaises(UnknownActionError):
+            dispatch(job)
+
+
+class SubprocessNotUsedTests(unittest.TestCase):
+    """Collectors must not import subprocess or open sockets to the target."""
+
+    def test_collectors_module_no_subprocess(self):
+        import agents.kali_pentest_agent.passive_collectors as pc
+        self.assertFalse(hasattr(pc, "subprocess"), "collectors must not import subprocess")
+
+    def test_collectors_module_no_socket(self):
+        import agents.kali_pentest_agent.passive_collectors as pc
+        self.assertFalse(hasattr(pc, "socket"), "collectors must not import socket")

--- a/agents/kali_pentest_agent/tests/test_runners.py
+++ b/agents/kali_pentest_agent/tests/test_runners.py
@@ -29,8 +29,9 @@ class FakeRunnerTests(unittest.TestCase):
             "params": {},
         }
 
-    def test_supported_actions_are_exactly_fake_runners(self):
-        self.assertEqual(SUPPORTED_ACTIONS, {"fake_dns_lookup", "fake_nuclei_scan"})
+    def test_supported_actions_includes_fake_runners(self):
+        self.assertIn("fake_dns_lookup", SUPPORTED_ACTIONS)
+        self.assertIn("fake_nuclei_scan", SUPPORTED_ACTIONS)
 
     def test_dns_lookup_is_deterministic(self):
         outputs, result = run_fake_dns_lookup(self.job)

--- a/agents/kali_pentest_agent/tests/test_worker_contract.py
+++ b/agents/kali_pentest_agent/tests/test_worker_contract.py
@@ -54,6 +54,41 @@ class WorkerContractTests(unittest.TestCase):
         self.assertEqual(client.post_output.call_count, 3)
         client.complete.assert_called_once()
 
+    @patch("agents.kali_pentest_agent.passive_collectors.collect_passive_dns")
+    @patch("agents.kali_pentest_agent.worker.django_client")
+    def test_full_passive_dns_cycle(self, client, collector):
+        passive_job = {
+            "job_id": "job-passive-001",
+            "action": "passive_dns_lookup",
+            "target": "app.example.com",
+            "params": {},
+        }
+        collector.return_value = (
+            [{"level": "info", "message": "passive dns ok"}],
+            {
+                "action": "passive_dns_lookup",
+                "target": "app.example.com",
+                "method": "passive",
+                "source": "system_resolver",
+                "collected_at": "2026-06-28T00:00:00+00:00",
+                "errors": [],
+                "records": {},
+            },
+        )
+        client.heartbeat.return_value = {"status": "ok"}
+        client.claim_job.return_value = {"status": "claimed", "job": passive_job}
+        client.mark_running.return_value = {"status": "running"}
+        client.post_output.return_value = {"output_id": "out-passive"}
+        client.complete.return_value = {"status": "completed"}
+
+        result = run_once()
+
+        self.assertEqual(result["status"], "ok")
+        collector.assert_called_once_with("app.example.com")
+        client.mark_running.assert_called_once_with("job-passive-001")
+        client.post_output.assert_called_once()
+        client.complete.assert_called_once()
+
     @patch("agents.kali_pentest_agent.worker.django_client")
     def test_posts_fail_if_runner_raises(self, client):
         bogus_job = {**self._job, "action": "rm -rf /"}

--- a/frontend/src/features/pentest/EngagementWorkspace.tsx
+++ b/frontend/src/features/pentest/EngagementWorkspace.tsx
@@ -276,6 +276,15 @@ export function EngagementWorkspace() {
               <button type="button" className={styles.devButton} onClick={() => { runFakeAgent() }}>
                 Run fake agent once
               </button>
+              <button type="button" className={styles.devButton} onClick={() => {
+                createJob(engagement.id, { action: 'passive_dns_lookup', target: engagement.target })
+              }}>Passive DNS</button>
+              <button type="button" className={styles.devButton} onClick={() => {
+                createJob(engagement.id, { action: 'domain_rdap_lookup', target: engagement.target })
+              }}>RDAP</button>
+              <button type="button" className={styles.devButton} onClick={() => {
+                createJob(engagement.id, { action: 'ct_subdomain_lookup', target: engagement.target })
+              }}>CT names</button>
               {jobs.length > 0 && (
                 <span className={styles.devInfo}>{jobs.filter(j => j.status === 'queued').length} queued, {jobs.length} total</span>
               )}

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,6 +89,9 @@ bleach>=6.1.0
 pycryptodome>=3.17.0
 python-json-logger>=2.0.0
 
+# Pentest passive tooling (5C)
+dnspython>=2.6.0
+
 # Development & Testing (Optional)
 # Install with: pip install -r requirements.txt[dev]
 # Uncomment the following lines locally only:


### PR DESCRIPTION
## Slice 5C — passive real OSINT tooling

The first slice that returns **real external intelligence** — strictly passive, **no direct contact with the target host**. Three real agent actions, all `informational` / approval-exempt, behind the full 5A/5B safety spine.

| Action | Provider (never the target) | Returns |
| --- | --- | --- |
| `passive_dns_lookup` | configured DNS resolver | A/AAAA/CNAME/MX/TXT/NS |
| `domain_rdap_lookup` | RDAP bootstrap (ARIN) | registration/network metadata |
| `ct_subdomain_lookup` | crt.sh | CT names (capped, deduped) |

### What lands
- **`execution_catalog`**: 3 passive actions (`requires_approval=False`, `touches_target_host=False`, `target_kind="domain"`).
- **`passive_validation.py`**: allowlist-based bare-domain validation on the **raw** target (before scope normalization) — rejects URLs/paths/queries/ports/wildcards/IPv4/numeric-TLD/single-label/whitespace/shell chars. Passive jobs require scope enforcement **and** shape validation.
- **`agent_views`**: server-side size caps (result ≤ 200KB, message ≤ 10k, non-string message rejected) — defense-in-depth over the agent caps, since any shared-token holder can POST results.
- **Agent `passive_collectors.py`**: real collectors hitting **providers only** — hardcoded provider hosts, target only an encoded query param, `timeout` + `verify=True` on every request, bounded/deduped results, provider errors → partial result with `errors` (not a hard fail), defensive bare-host re-validation.
- **CI**: `main.yml` now runs the agent unit tests so the collector safety tests (no-target-contact, no-subprocess/socket, mocked network) **gate merges**. `dnspython` added to root + agent requirements.
- **Frontend**: dev/operator Passive DNS / RDAP / CT buttons (queue against `engagement.target`; server-validated).

### Rotation & QA
DeepSeek implemented → Codex QA'd+fixed (7 issues) → **Claude final adversarial QA**. Mutation-verified the spine: validation gate, server-side size caps, and the **collector no-target-as-host** proof (pointing a collector at the target fails its test). Bandit on the 5C code is clean.

Claude QA found + fixed a coverage gap: the validator's **IPv4 / numeric-TLD / single-label** rejections were vacuously tested — their cases were out-of-scope, so `enforce_engagement_scope` caught them, not the validator. Added 3 isolating tests with **in-scope-but-shape-invalid** targets (IP in a CIDR scope, numeric-TLD host in scope, single-label host in scope); mutation-verified. Also **force-added** the gitignored agent collector tests (`tests/` is blanket-ignored) so CI actually runs them.

### Verification
- `pentest` suite → **187 OK** (incl. passive **21 OK**) · agent unit → **29 OK**
- `makemigrations --check` → no changes (migration-free) · `manage.py check` → clean · Bandit → clean

### Boundary
No subprocess/shell/socket-to-target; collectors talk only to DNS resolvers / fixed providers (asserted in tests by inspecting the request URL host). 5C is passive-only. Out of scope: 5C-2 low-active probes, 5D approved high-active execution, 5E raw-evidence → findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
