### PR TITLE
infra: add Railway Temporal and pentest agent deploy files

### DIFF
--- a/deploy/railway/pentest-agent/Dockerfile
+++ b/deploy/railway/pentest-agent/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY agents/kali_pentest_agent/requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements.txt
+
+COPY agents /app/agents
+COPY deploy/railway/pentest-agent/agent_loop.py /app/agent_loop.py
+
+RUN useradd --create-home --shell /usr/sbin/nologin agent
+USER agent
+
+CMD ["python", "/app/agent_loop.py"]

--- a/deploy/railway/pentest-agent/agent_loop.py
+++ b/deploy/railway/pentest-agent/agent_loop.py
@@ -1,0 +1,39 @@
+"""Railway entrypoint for the pentest agent poller.
+
+This process does not expose HTTP. It heartbeats, claims one compatible job,
+runs it, sleeps, and repeats. Current checkout supports the safe fake runners.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from agents.kali_pentest_agent import config
+from agents.kali_pentest_agent.worker import run_once
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("pentest_agent_loop")
+
+
+def main() -> None:
+    logger.info(
+        "starting pentest agent poll loop: agent_id=%s interval=%ss",
+        config.AGENT_ID,
+        config.POLL_INTERVAL_SECONDS,
+    )
+    while True:
+        try:
+            result = run_once()
+            logger.info("poll result: %s", result)
+        except Exception:
+            logger.exception("poll cycle failed")
+        time.sleep(max(config.POLL_INTERVAL_SECONDS, 1))
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/railway/temporal-worker/Dockerfile
+++ b/deploy/railway/temporal-worker/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    SKIP_MIGRATIONS=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    netcat-openbsd \
+    ffmpeg \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN addgroup --system django && adduser --system --group django
+
+COPY requirements.txt /app/
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . /app/
+
+RUN chmod +x /app/entrypoint.sh /app/scripts/railway/temporal_worker.sh \
+    && chown -R django:django /app
+
+USER django
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["sh", "-c", "cd /app/Backend && exec python manage.py start_temporal_worker"]

--- a/deploy/railway/temporal/Dockerfile
+++ b/deploy/railway/temporal/Dockerfile
@@ -1,0 +1,7 @@
+FROM temporalio/auto-setup:1.29.3
+
+USER root
+RUN mkdir -p /etc/temporal/config/dynamicconfig
+
+COPY deploy/railway/temporal/development-sql.yaml /etc/temporal/config/dynamicconfig/development-sql.yaml
+

--- a/deploy/railway/temporal/development-sql.yaml
+++ b/deploy/railway/temporal/development-sql.yaml
@@ -1,0 +1,7 @@
+limit.maxIDLength:
+  - value: 255
+    constraints: {}
+
+system.forceSearchAttributesCacheRefreshOnRead:
+  - value: true
+    constraints: {}


### PR DESCRIPTION
﻿## Summary
- Add Railway deploy Dockerfiles for Temporal server and Temporal worker.
- Add a Railway pentest smoke-agent container with a private polling loop.
- Bake the Temporal dynamic config file required by the self-hosted auto-setup image.

## Why
Railway services now reference these paths for the deployed Temporal and pentest-agent services. Committing them makes rebuilds reproducible from GitHub instead of depending on local-only files.

## Validation
- Deployed to Railway from this branch.
- `temporal-server` reports SUCCESS and registered the default namespace.
- `temporal-worker` reports SUCCESS and Temporal logs show `user-workflows` pollers connected.
- `pentest-agent-smoke` reports SUCCESS and logs show backend polling/heartbeat with no queued jobs.
