### PR TITLE
infra: add Railway deploy files (pentest agent + temporal) to master

### DIFF
--- a/deploy/railway/pentest-agent/Dockerfile
+++ b/deploy/railway/pentest-agent/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY agents/kali_pentest_agent/requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements.txt
+
+COPY agents /app/agents
+COPY deploy/railway/pentest-agent/agent_loop.py /app/agent_loop.py
+
+RUN useradd --create-home --shell /usr/sbin/nologin agent
+USER agent
+
+CMD ["python", "/app/agent_loop.py"]

--- a/deploy/railway/pentest-agent/agent_loop.py
+++ b/deploy/railway/pentest-agent/agent_loop.py
@@ -1,0 +1,40 @@
+"""Railway entrypoint for the pentest agent poller.
+
+This process does not expose HTTP. It heartbeats, claims one compatible job,
+runs it, sleeps, and repeats. It executes only the server-allowlisted actions
+the agent's runners support (fake runners + 5C passive OSINT on current master).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from agents.kali_pentest_agent import config
+from agents.kali_pentest_agent.worker import run_once
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("pentest_agent_loop")
+
+
+def main() -> None:
+    logger.info(
+        "starting pentest agent poll loop: agent_id=%s interval=%ss",
+        config.AGENT_ID,
+        config.POLL_INTERVAL_SECONDS,
+    )
+    while True:
+        try:
+            result = run_once()
+            logger.info("poll result: %s", result)
+        except Exception:
+            logger.exception("poll cycle failed")
+        time.sleep(max(config.POLL_INTERVAL_SECONDS, 1))
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/railway/temporal-worker/Dockerfile
+++ b/deploy/railway/temporal-worker/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    SKIP_MIGRATIONS=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    netcat-openbsd \
+    ffmpeg \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN addgroup --system django && adduser --system --group django
+
+COPY requirements.txt /app/
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+COPY . /app/
+
+RUN chmod +x /app/entrypoint.sh /app/scripts/railway/temporal_worker.sh \
+    && chown -R django:django /app
+
+USER django
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["sh", "-c", "cd /app/Backend && exec python manage.py start_temporal_worker"]

--- a/deploy/railway/temporal/Dockerfile
+++ b/deploy/railway/temporal/Dockerfile
@@ -1,0 +1,7 @@
+FROM temporalio/auto-setup:1.29.3
+
+USER root
+RUN mkdir -p /etc/temporal/config/dynamicconfig
+
+COPY deploy/railway/temporal/development-sql.yaml /etc/temporal/config/dynamicconfig/development-sql.yaml
+

--- a/deploy/railway/temporal/development-sql.yaml
+++ b/deploy/railway/temporal/development-sql.yaml
@@ -1,0 +1,7 @@
+limit.maxIDLength:
+  - value: 255
+    constraints: {}
+
+system.forceSearchAttributesCacheRefreshOnRead:
+  - value: true
+    constraints: {}


### PR DESCRIPTION
## Add Railway deploy files to master (single source of truth)

Codex created the Railway deploy artifacts for the pentest agent + temporal, but they lived only in an **untracked local dir** / a **pre-5C branch** (`infra/railway-temporal-agent`, forked before #25). Result: `master` — which has the current app **and the 5C agent code** — had **no way to build the agent/temporal images from version control**, and the running `pentest-agent-smoke` was built via ad-hoc `railway up` from a stale (fake-only) checkout.

This adds those files to `master` so it's one source of truth (app 5C + deploy infra), enabling **reproducible, GitHub-based deploys**.

### Files
- `deploy/railway/pentest-agent/Dockerfile` + `agent_loop.py` — the poller image (COPYs `agents/`, runs the heartbeat → claim → run loop, non-root). **On `master`, `agents/` is the 5C build** (passive collectors + `dnspython`), so images built from here run **real passive OSINT**, not just fake runners.
- `deploy/railway/temporal/Dockerfile` + `development-sql.yaml`, `deploy/railway/temporal-worker/Dockerfile`.

Also corrects the `agent_loop.py` docstring (previously said "fake runners" only).

### Why this matters (context)
An end-to-end smoke on prod showed the deployed agent sitting idle on queued **passive** jobs because its image predated 5C (advertised only `fake_*` capabilities). `web ui` is already on 5C (it accepted the passive jobs); the agent image was the gap. Merging this and pointing `pentest-agent-smoke` at `master` (or re-`railway up`) yields an agent that processes the passive OSINT actions.

Docs/infra only — no app code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
