### PR TITLE
fix(pentest): scrollable domain pages + surface job results in workspace

### DIFF
--- a/frontend/src/components/layout/DomainLayout.module.css
+++ b/frontend/src/components/layout/DomainLayout.module.css
@@ -256,7 +256,9 @@
 }
 
 .contentArea {
-  overflow: hidden;
+  /* Scroll long domain pages (engagement lists, etc.) instead of clipping them;
+     also gives PageScaffold's sticky "focused-detail" header a scroll ancestor. */
+  overflow-y: auto;
 }
 
 .chatArea {

--- a/frontend/src/features/pentest/EngagementWorkspace.module.css
+++ b/frontend/src/features/pentest/EngagementWorkspace.module.css
@@ -235,3 +235,68 @@
   font-size: 12px;
   color: var(--text-subtle);
 }
+
+.jobsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+}
+
+.jobRow {
+  border-block-start: 1px solid var(--border-color);
+  padding-block: var(--space-xs);
+}
+
+.jobRow:first-of-type {
+  border-block-start: none;
+}
+
+.jobSummary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  cursor: pointer;
+  list-style: none;
+}
+
+.jobAction {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: var(--font-weight-semibold);
+}
+
+.jobTarget {
+  color: var(--text-subtle);
+  font-size: 12px;
+}
+
+.jobResult {
+  margin-block-start: var(--space-xs);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  background: var(--surface-muted, var(--app-bg));
+  border: 1px solid var(--border-color);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  max-block-size: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.jobError {
+  margin-block-start: var(--space-xs);
+  color: var(--error-color, #ef4444);
+  font-size: 12px;
+}
+
+.jobMeta {
+  margin-block-start: var(--space-xs);
+  color: var(--text-subtle);
+  font-size: 12px;
+}

--- a/frontend/src/features/pentest/EngagementWorkspace.tsx
+++ b/frontend/src/features/pentest/EngagementWorkspace.tsx
@@ -254,6 +254,30 @@ export function EngagementWorkspace() {
 
           <LiveOutput lines={lines} />
 
+          {jobs.length > 0 && (
+            <div className={styles.jobsPanel}>
+              <div className={styles.panelTitle}>Execution jobs &amp; results</div>
+              {jobs.map((job) => (
+                <details key={job.id} className={styles.jobRow} open={job.status === 'completed' || job.status === 'failed'}>
+                  <summary className={styles.jobSummary}>
+                    <span className={styles.jobAction}>{job.action}</span>
+                    <StatusBadge
+                      label={job.status}
+                      tone={job.status === 'completed' ? 'success' : job.status === 'failed' ? 'critical' : job.status === 'running' ? 'info' : 'warning'}
+                    />
+                    <span className={styles.jobTarget}>{job.target}</span>
+                  </summary>
+                  {job.errorMessage ? <div className={styles.jobError}>{job.errorMessage}</div> : null}
+                  {job.result && Object.keys(job.result).length > 0 ? (
+                    <pre className={styles.jobResult}>{JSON.stringify(job.result, null, 2)}</pre>
+                  ) : (
+                    <div className={styles.jobMeta}>No result yet — waiting for the agent.</div>
+                  )}
+                </details>
+              ))}
+            </div>
+          )}
+
           {approvalRequest ? <ConfirmationGate request={approvalRequest} onApprove={approveApproval} onReject={rejectApproval} /> : null}
 
           <div className={styles.statusBar}>

--- a/frontend/src/stores/pentestStore.ts
+++ b/frontend/src/stores/pentestStore.ts
@@ -99,6 +99,7 @@ function mapJob(j: ExecutionJobResponse): ExecutionJob {
     status: j.status,
     approvalId: j.approval_id ?? null,
     errorMessage: j.error_message,
+    result: j.result,
     claimedBy: j.claimed_by,
     claimedAt: j.claimed_at ?? null,
     startedAt: j.started_at ?? null,

--- a/frontend/src/types/pentest.ts
+++ b/frontend/src/types/pentest.ts
@@ -80,6 +80,7 @@ export interface ExecutionJob {
   status: string
   approvalId?: number | null
   errorMessage?: string
+  result?: Record<string, unknown>
   claimedBy?: string
   claimedAt?: string | null
   startedAt?: string | null


### PR DESCRIPTION
Fixes two UI bugs from the prod OSINT smoke: (1) the engagement list showed only the first row / wouldn't scroll -- DomainLayout .contentArea was height:100%/overflow:hidden with no inner scroll container, so tall pages got clipped; changed to overflow-y:auto (also gives the sticky focused-detail header a scroll ancestor). (2) real job results (passive DNS/RDAP/CT) weren't shown anywhere -- job.result was dropped on the frontend; now carried through the type + mapJob and rendered in a new 'Execution jobs and results' panel in EngagementWorkspace. Frontend only; typecheck + eslint clean.