### PR TITLE
chore(infra): optional embedded Celery beat in the worker

### DIFF
--- a/scripts/railway/celery_worker.sh
+++ b/scripts/railway/celery_worker.sh
@@ -13,6 +13,15 @@ else
   SCALE_ARGS="--concurrency ${CELERY_CONCURRENCY:-1}"
 fi
 
-exec celery -A Backend worker -l info --pool ${POOL} ${SCALE_ARGS} \
+# Optional embedded beat: run the scheduler inside this worker so a separate
+# "Celery beat" service isn't needed. SAFE ONLY with a SINGLE worker replica —
+# with >1 replica each would run beat and fire duplicate scheduled tasks.
+# Enable by setting CELERY_EMBED_BEAT=true on this service (and keep replicas=1).
+BEAT_ARGS=""
+if [ "${CELERY_EMBED_BEAT:-false}" = "true" ]; then
+  BEAT_ARGS="--beat --scheduler django_celery_beat.schedulers:DatabaseScheduler"
+fi
+
+exec celery -A Backend worker -l info --pool ${POOL} ${SCALE_ARGS} ${BEAT_ARGS} \
   --max-tasks-per-child ${MAX_TASKS} \
   --max-memory-per-child ${MAX_MEM}


### PR DESCRIPTION
Adds a CELERY_EMBED_BEAT env toggle to scripts/railway/celery_worker.sh so the worker can run beat in-process (--beat --scheduler django_celery_beat.schedulers:DatabaseScheduler), letting us drop the separate Celery beat Railway service for a small cost saving. Defaults OFF (unchanged behavior). Safe because the worker runs at concurrency 1 / single replica -- guarded with a comment that it must not be used with >1 replica (duplicate schedules). Rollout: deploy -> set CELERY_EMBED_BEAT=true on the worker -> confirm 'beat: Starting...' in logs -> then remove the Celery beat service.